### PR TITLE
Build a Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts AS dependencies
+WORKDIR /app
+ADD package.json package-lock.json /app/
+RUN npm clean-install --frozen-lockfile
+
+FROM dependencies AS build
+WORKDIR /app
+ADD . /app/
+COPY --from=dependencies /app/node_modules /app/node_modules
+RUN npm run build
+
+FROM nginx:stable AS release
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80


### PR DESCRIPTION
This PR adds the ability to build a Docker image, as requested by https://github.com/j2qk3b/ebook-demo/issues/2

To do so, run:
```
docker build -t <IMAGE_NAME> -f docker/Dockerfile .
```
Please replace `<IMAGE_NAME>` with your custom Docker image name.

You can then publish it to Docker Hub with:
```
docker publish <IMAGE_NAME>
```

If you want to try it, I built a public example available here: https://hub.docker.com/repository/docker/e7db/ebook-demo
You can, for example, test it locally on port 8123with:
```
docker run --rm -p 8123:80 e7db/ebook-demo
```
Then go to: http://localhost:8123

I did not add anything on the README.md, as I prefer to let you word it as you please.
Cheers.